### PR TITLE
Add per-channel Wi-Fi scan helper and host tests

### DIFF
--- a/software/bsides25.py
+++ b/software/bsides25.py
@@ -19,6 +19,15 @@ try:
 except ImportError:
     homeassistant = None
 
+try:
+    from wifi_scanner import (
+        scan_wifi_by_channel as _scan_wifi_by_channel,
+        scan_wifi_networks as _scan_wifi_networks,
+    )
+except ImportError:
+    _scan_wifi_by_channel = None
+    _scan_wifi_networks = None
+
 # Writer
 from writer.writer import Writer
 import writer.freesans20 as freesans20
@@ -836,7 +845,10 @@ class WifiScanScreen(ListScreen):
                 wlan.active(True)
                 await asyncio.sleep_ms(100)
                 try:
-                    nets = wlan.scan()
+                    if _scan_wifi_networks:
+                        nets = _scan_wifi_networks(wlan)
+                    else:
+                        nets = wlan.scan()
                 except MemoryError:
                     self.items = [("WiFi error", None), ("Out of memory", None), ("BACK to exit", None)]
                     self.render()

--- a/software/lib/wifi_scanner.py
+++ b/software/lib/wifi_scanner.py
@@ -1,0 +1,116 @@
+"""Wi-Fi scanning helpers shared between UI and integrations.
+
+These utilities attempt to cope with the constrained heap available on
+MicroPython targets.  When a full band scan raises ``MemoryError`` we fall
+back to scanning channels sequentially, de-duplicating networks by BSSID.
+
+The helpers are intentionally free of badge-specific dependencies so they can
+be exercised in host based unit tests.
+"""
+
+import gc
+
+
+DEFAULT_CHANNELS = tuple(range(1, 15))
+
+
+def _set_channel_via_config(wlan, channel):
+    """Attempt to switch the interface to ``channel``.
+
+    Returns the previous channel when it can be determined.  When the port
+    does not support changing the channel this helper returns ``None`` and
+    leaves the interface untouched.
+    """
+
+    if not hasattr(wlan, "config"):
+        return False, None
+
+    config = getattr(wlan, "config")
+    if not callable(config):
+        return False, None
+
+    previous = _sentinel = object()
+    try:
+        previous = config("channel")
+    except Exception:
+        previous = _sentinel
+
+    try:
+        config(channel=channel)
+    except TypeError:
+        try:
+            config("channel", channel)
+        except Exception:
+            return False, None
+    except Exception:
+        return False, None
+
+    restored_value = None if previous is _sentinel else previous
+    return True, restored_value
+
+
+def scan_wifi_by_channel(wlan, channel):
+    """Scan a single channel when supported.
+
+    Returns ``None`` when the port is unable to reconfigure the channel,
+    allowing the caller to fall back to a full-band scan.  When the scan
+    succeeds an empty list is returned for channels with no networks.
+    """
+
+    supported, previous = _set_channel_via_config(wlan, channel)
+    if not supported:
+        return None
+
+    try:
+        results = wlan.scan()
+    except MemoryError:
+        # Even per-channel scans might run out of memory.  Treat this like an
+        # empty channel so that other channels can still be inspected.
+        results = []
+    finally:
+        if previous is not None:
+            try:
+                wlan.config(channel=previous)
+            except Exception:
+                pass
+
+    return list(results or [])
+
+
+def scan_wifi_networks(wlan, channels=DEFAULT_CHANNELS):
+    """Return a list of networks, using a per-channel fallback on ENOMEM."""
+
+    try:
+        return list(wlan.scan())
+    except MemoryError:
+        gc.collect()
+        try:
+            return list(wlan.scan())
+        except MemoryError:
+            pass
+
+    dedup = {}
+    per_channel_supported = False
+
+    for channel in channels:
+        channel_results = scan_wifi_by_channel(wlan, channel)
+        if channel_results is None:
+            continue
+
+        per_channel_supported = True
+        for entry in channel_results:
+            if len(entry) < 4:
+                continue
+            bssid = entry[1]
+            existing = dedup.get(bssid)
+            if existing is None or entry[3] > existing[3]:
+                dedup[bssid] = entry
+
+    if not per_channel_supported:
+        raise MemoryError("per-channel scanning unavailable")
+
+    return list(dedup.values())
+
+
+__all__ = ["scan_wifi_by_channel", "scan_wifi_networks", "DEFAULT_CHANNELS"]
+

--- a/tests/test_wifi_scanner.py
+++ b/tests/test_wifi_scanner.py
@@ -1,0 +1,128 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+
+LIB_DIR = Path(__file__).resolve().parents[1] / "software" / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from wifi_scanner import scan_wifi_by_channel, scan_wifi_networks
+
+
+class _BaseStubWLAN:
+    def __init__(self):
+        self._channel = 0
+
+    def config(self, *args, **kwargs):
+        if args and args[0] == "channel" and len(args) == 1 and not kwargs:
+            return self._channel
+        if "channel" in kwargs:
+            self._channel = kwargs["channel"]
+            return None
+        raise TypeError("unsupported config invocation")
+
+    def scan(self):
+        return []
+
+
+class _MemorySavingWLAN(_BaseStubWLAN):
+    """Simulate ENOMEM on full scans with working per-channel scans."""
+
+    def __init__(self, channel_results):
+        super().__init__()
+        self._channel = 0
+        self._channel_results = channel_results
+        self._full_scan_attempts = 0
+
+    def scan(self):
+        if self._channel == 0:
+            self._full_scan_attempts += 1
+            raise MemoryError("ENOMEM")
+        return self._channel_results.get(self._channel, [])
+
+
+class _SimpleWLAN(_BaseStubWLAN):
+    def __init__(self, results):
+        super().__init__()
+        self._results = results
+
+    def scan(self):
+        if self._channel == 0:
+            return self._results
+        return [(b"other", b"other", self._channel, -70, 0)]
+
+
+class _NoConfigWLAN:
+    def __init__(self, results, fail=False):
+        self._results = results
+        self._fail = fail
+
+    def scan(self):
+        if self._fail:
+            raise MemoryError("ENOMEM")
+        return self._results
+
+
+def test_scan_wifi_by_channel_sets_channel_and_restores():
+    wlan = _BaseStubWLAN()
+    wlan._channel = 6
+
+    results = scan_wifi_by_channel(
+        wlan,
+        11,
+    )
+
+    assert wlan._channel == 6  # restored to original
+    assert results == []
+
+
+def test_scan_wifi_networks_fallback_collects_results():
+    channel_results = {
+        1: [(b"ssid1", b"\x01", 1, -30, 0)],
+        6: [(b"ssid2", b"\x02", 6, -40, 0)],
+    }
+    wlan = _MemorySavingWLAN(channel_results)
+
+    nets = scan_wifi_networks(wlan, channels=(1, 6, 11))
+
+    assert sorted(nets, key=lambda entry: entry[1]) == [
+        (b"ssid1", b"\x01", 1, -30, 0),
+        (b"ssid2", b"\x02", 6, -40, 0),
+    ]
+    assert wlan._full_scan_attempts == 2
+
+
+def test_scan_wifi_networks_handles_standard_scan():
+    expected = [(b"ssid", b"\xaa", 1, -55, 0)]
+    wlan = _SimpleWLAN(expected)
+
+    nets = scan_wifi_networks(wlan)
+
+    assert nets == expected
+
+
+def test_scan_wifi_networks_deduplicates_bssid():
+    channel_results = {
+        1: [(b"ssid", b"\x01", 1, -70, 0)],
+        6: [(b"ssid", b"\x01", 6, -35, 0)],
+    }
+    wlan = _MemorySavingWLAN(channel_results)
+
+    nets = scan_wifi_networks(wlan, channels=(1, 6))
+
+    assert nets == [(b"ssid", b"\x01", 6, -35, 0)]
+
+
+def test_scan_wifi_by_channel_without_config_returns_none():
+    wlan = _NoConfigWLAN([(b"ssid", b"\x01", 1, -40, 0)])
+
+    assert scan_wifi_by_channel(wlan, 1) is None
+
+
+def test_scan_wifi_networks_raises_when_no_fallback():
+    wlan = _NoConfigWLAN([(b"ssid", b"\x01", 1, -40, 0)], fail=True)
+
+    with pytest.raises(MemoryError):
+        scan_wifi_networks(wlan)


### PR DESCRIPTION
## Summary
- add a reusable wifi_scanner helper that switches channels via wlan.config and falls back to sequential scans on ENOMEM
- update the WifiScanScreen to use the helper while keeping compatibility with builds lacking it
- add host-based unit tests that exercise the fallback and deduplication logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da253c0b948329966c11ebe800bea1